### PR TITLE
Attach stdio so `plantuml -pipe` works correctly

### DIFF
--- a/run-plantuml
+++ b/run-plantuml
@@ -5,7 +5,7 @@ __run_plantuml() {
     local host_src_volume="${PWD}"
     local container_dest_volume="/work"
 
-    docker run --volume="${host_src_volume}:${container_dest_volume}" --workdir="${container_dest_volume}" --rm "${docker_image}" $@
+    docker run --volume="${host_src_volume}:${container_dest_volume}" --workdir="${container_dest_volume}" --rm --attach=stdin --attach=stdout --interactive "${docker_image}" $@
 }
 
 __run_plantuml $@


### PR DESCRIPTION
## Problem

Docker doesn't automatically attach stdin to the container. This prevents tools such as [sphinxcontrib-plantuml](https://pypi.python.org/pypi/sphinxcontrib-plantuml) from working correctly, as they use PlantUML's `-pipe` option rather than using intermediate files.
## Solution

Add docker options to the `run-plantuml` wrapper script to attach stdio.
