### PR TITLE
added default skinparam files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,11 @@ ENV LANG en_US.UTF-8
 RUN apk add --no-cache graphviz ttf-droid ttf-droid-nonlatin curl \
     && mkdir /app \
     && curl -L https://sourceforge.net/projects/plantuml/files/plantuml.${PLANTUML_VERSION}.jar/download -o /app/plantuml.jar \
-    && apk del curl
+    && apk del curl \ 
+    && mkdir /app/skinparams
 
-ENTRYPOINT [ "java", "-jar", "/app/plantuml.jar" ]
+COPY resources/*.skinparam /app/skinparams
+
+ENTRYPOINT ["java","-jar","/app/plantuml.jar","-I/app/skinparams/*.skinparam"]
 CMD [ "-h" ]
+# ENTRYPOINT ["cat"]


### PR DESCRIPTION
Since I found myself always importing the skinparam files, I thought it would be a good inclusion to add them to the docker image so that they're always there

Here are some examples of skinparam files:

- https://github.com/rbkmoney/plantuml-toolset/blob/master/skin.iwsd
- https://github.com/spiegel-im-spiegel/plantuml-sample/blob/master/skinparams.iuml
- https://github.com/qjebbs/vscode-plantuml/blob/master/includes/styles/blue.wsd

2 important aspects are:
- the files should end in `*.skinparam`
- the files should not have `@startuml .... @enduml`, otherwise they will eclipse the file that you actually want to render

