### PR TITLE
attached the stderr to the docker run command

### DIFF
--- a/run-plantuml
+++ b/run-plantuml
@@ -5,7 +5,7 @@ __run_plantuml() {
     local host_src_volume="${PWD}"
     local container_dest_volume="/work"
 
-    exec docker run --volume="${host_src_volume}:${container_dest_volume}" --workdir="${container_dest_volume}" --rm --attach=stdin --attach=stdout --interactive "${docker_image}" "$@"
+    exec docker run --volume="${host_src_volume}:${container_dest_volume}" --workdir="${container_dest_volume}" --rm --attach=stdin --attach=stdout --attach=stderr --interactive "${docker_image}" "$@"
 }
 
 __run_plantuml "$@"


### PR DESCRIPTION
I was having some trouble finding out why my `.puml` file wasn't being rendered and I found attaching the stderr quite helpful in debugging it, so I thought it might benefit other people as well

I guess this might not be desirable when passing the rendered diagrams directly through stdout, but I can't imagine that that's a popular method of doing it