### PR TITLE
Add buildx to build arm64 image for mac m1

### DIFF
--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -13,11 +13,30 @@ jobs:
         with:
           fetch-depth: 1
 
-      - uses: mr-smithers-excellent/docker-build-push@v5
-        name: Build and push Docker image
+      - name: Get latest tag version
+        id: extract-version
+        run: echo "version=$(git describe --tags --abbrev=0)" >> $GITHUB_OUTPUT
+
+      - name: Remove '-docker' suffix from repository_owner
+        id: extract-repository-owner
+        run: echo "repository_owner=$(echo ${{ github.repository_owner }} | sed 's/-docker//')" >> $GITHUB_OUTPUT
+
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
         with:
-          image: miy4/plantuml
-          addLatest: true
-          registry: docker.io
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build docker image
+        run: |-
+            docker buildx build \
+              --platform linux/arm64,linux/amd64 \
+              -t ${{ steps.extract-repository-owner.outputs.repository_owner }}/plantuml:${{ steps.extract-version.outputs.version }} \
+              -t ${{ steps.extract-repository-owner.outputs.repository_owner }}/plantuml:latest \
+              --push .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/alpine:3
+FROM docker.io/alpine:3.16
 
 ENV PLANTUML_VERSION 1.2022.6
 ENV LANG en_US.UTF-8


### PR DESCRIPTION
* Add `buildx` instead of just `build` in GH Action
* Add `arm64` platform, successfully tested on my image `werwolfby/plantuml:1.2022.6`
* Use hardcoded `alpine:3.16` base image that has `ttf-droid-nonlatin`, because latest `3.17` doesn't (don't know why)
* Create generic `GH` action that should be able to push to personal repository based on username, with trimmed `-docker` suffix. I have a separate organization `werwolfby-docker` for docker related repositories.